### PR TITLE
Update Open-Meteo KMA provider

### DIFF
--- a/app/providers/weather_openmeteo_kma.py
+++ b/app/providers/weather_openmeteo_kma.py
@@ -1,0 +1,24 @@
+from typing import Optional
+
+import httpx
+from fastapi import HTTPException
+
+BASE = "https://api.open-meteo.com/v1/forecast"
+
+
+async def get_daily_summary(latitude: float, longitude: float) -> Optional[dict]:
+    """Fetch a daily weather summary from the Open-Meteo KMA model."""
+    params = {
+        "latitude": latitude,
+        "longitude": longitude,
+        "daily": "weathercode,temperature_2m_max,temperature_2m_min",
+        "timezone": "Asia/Seoul",
+        "models": "kma",
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(BASE, params=params)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise HTTPException(status_code=502) from exc
+    return response.json().get("daily")


### PR DESCRIPTION
## Summary
- Add provider for Open-Meteo KMA using latest endpoint and models parameter
- Handle HTTPStatusError when fetching daily summary

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5203f7774832a9037427522cb7015